### PR TITLE
Test on newer Python versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
-tags
-*.py[co]
-*.sw[po]
 *.egg-info*
 *.pot
-docs/_build*
+*.py[co]
+*.sw[po]
+.eggs
 build
 dist
+docs/_build*
+tags

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 language: python
+cache: pip
+
 python:
  - 2.7
- - 3.3
- - "pypy"
+ - 3.5
+ - 3.6
+ - 3.7
+ - 3.8
+ - 3.9-dev
+ - pypy
+ - pypy3
 
 script: python setup.py test
-

--- a/setup.py
+++ b/setup.py
@@ -4,33 +4,37 @@
 """Setup script for humanize."""
 
 from setuptools import setup, find_packages
-import sys, os
 import io
 
 version = '0.5.1'
-
-# some trove classifiers:
-
 
 setup(
     name='humanize',
     version=version,
     description="python humanize utilities",
     long_description=io.open('README.rst', 'r', encoding="UTF-8").read(),
-    # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
+    # Get strings from https://pypi.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: POSIX',
-        'Programming Language :: Python :: 3',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
     ],
     keywords='humanize time size',
     author='Jason Moiron',
     author_email='jmoiron@jmoiron.net',
 
-    url='http://github.com/jmoiron/humanize',
+    url='https://github.com/jmoiron/humanize',
     license='MIT',
     packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
     include_package_data=True,


### PR DESCRIPTION
From https://github.com/jmoiron/humanize/pull/84

> Also cache pip, and update Trove classifiers to match tested versions (the currently supported CPython versions 3.5-3.8, plus 2.7).