### PR TITLE
make VERSION match reality

### DIFF
--- a/humanize/__init__.py
+++ b/humanize/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0,4)
+VERSION = (0,5,1)
 
 from humanize.time import *
 from humanize.number import *


### PR DESCRIPTION
From https://github.com/jmoiron/humanize/pull/31

> It's also pretty common to use `__version__` to report the module's version, but I didn't want to completely change this ;)
