### PR TITLE
Pin mkdocstrings to 0.28.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 mkdocs==1.6.1
 mkdocs-include-markdown-plugin
 mkdocs-material
-mkdocstrings[python]==0.28.2
+mkdocstrings[python]==0.28.0
 pygments
 pymdown-extensions==10.14.3


### PR DESCRIPTION
Testing if underscore methods are shown.

https://mkdocstrings.github.io/python/usage/configuration/members/#filters